### PR TITLE
fix android12 build

### DIFF
--- a/android/src/vendor/AndroidManifest.xml
+++ b/android/src/vendor/AndroidManifest.xml
@@ -22,10 +22,11 @@
         <uses-library
             android:name="org.apache.http.legacy"
             android:required="false" />
-
+        <!-- targetSdkVersion>=31 -> Android 12 android:exported -->
         <activity
             android:name="com.tencent.tauth.AuthActivity"
             android:launchMode="singleTask"
+            android:exported="true"
             android:noHistory="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined