### PR TITLE
增加对 ServerSide 登录模式的支持

### DIFF
--- a/android/src/main/java/io/github/v7lin/tencent_kit/TencentKitPlugin.java
+++ b/android/src/main/java/io/github/v7lin/tencent_kit/TencentKitPlugin.java
@@ -160,6 +160,8 @@ public class TencentKitPlugin implements FlutterPlugin, ActivityAware, ActivityR
             result.success(tencent != null && isAppInstalled(applicationContext, "com.tencent.tim"));
         } else if ("login".equals(call.method)) {
             login(call, result);
+        } else if ("loginServerSide".equals(call.method)) {
+            loginServerSide(call, result);
         } else if ("logout".equals(call.method)) {
             logout(call, result);
         } else if ("shareMood".equals(call.method)) {
@@ -181,6 +183,14 @@ public class TencentKitPlugin implements FlutterPlugin, ActivityAware, ActivityR
         final String scope = call.argument("scope");
         if (tencent != null) {
             tencent.login(activityPluginBinding.getActivity(), scope, loginListener);
+        }
+        result.success(null);
+    }
+
+    private void loginServerSide(@NonNull MethodCall call, @NonNull Result result) {
+        final String scope = call.argument("scope");
+        if (tencent != null) {
+            tencent.loginServerSide(activityPluginBinding.getActivity(), scope, loginListener);
         }
         result.success(null);
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -108,6 +108,14 @@ class _HomeState extends State<Home> {
             },
           ),
           ListTile(
+            title: Text('登录(Server-Side)'),
+            onTap: () {
+              TencentKitPlatform.instance.loginServerSide(
+                scope: <String>[TencentScope.kGetUserInfo],
+              );
+            },
+          ),
+          ListTile(
             title: Text('获取用户信息'),
             onTap: () async {
               if ((_loginResp?.isSuccessful ?? false) &&

--- a/lib/src/tencent_kit_method_channel.dart
+++ b/lib/src/tencent_kit_method_channel.dart
@@ -84,6 +84,18 @@ class MethodChannelTencentKit extends TencentKitPlatform {
   }
 
   @override
+  Future<void> loginServerSide({
+    required List<String> scope,
+  }) {
+    return methodChannel.invokeMethod<void>(
+      'loginServerSide',
+      <String, dynamic>{
+        'scope': scope.join(','),
+      },
+    );
+  }
+
+  @override
   Future<void> logout() {
     return methodChannel.invokeMethod<void>('logout');
   }

--- a/lib/src/tencent_kit_platform_interface.dart
+++ b/lib/src/tencent_kit_platform_interface.dart
@@ -65,6 +65,14 @@ abstract class TencentKitPlatform extends PlatformInterface {
         'login({required scope}) has not been implemented.');
   }
 
+  /// 登录（Server-Side）
+  Future<void> loginServerSide({
+    required List<String> scope,
+  }) {
+    throw UnimplementedError(
+        'loginServerSide({required scope}) has not been implemented.');
+  }
+
   /// 登出
   Future<void> logout() {
     throw UnimplementedError('logout() has not been implemented.');


### PR DESCRIPTION
两种登录方式生成的 AccessToken 对于服务端来说是不同的。
即若服务端侧需要用到的 AccessToken 为 ServerSide 登录模式下的，那么就需要客户端侧通过 Tencent. loginServerSide() 的方式去登录。
针对以上问题，提交了一下 PR，代码很简单，还望空了看看 : )

官方文档：https://wiki.connect.qq.com/server-side%E7%99%BB%E5%BD%95%E6%A8%A1%E5%BC%8F