### PR TITLE
添加 Android 命名空间

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,6 +39,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    if (project.android.hasProperty('namespace') ||
+            getGradle().getGradleVersion().substring(0, 1).toInteger() >= 8) {
+        namespace 'io.github.v7lin.tencent_kit'
+    }
+    
     compileSdkVersion 31
 
     compileOptions {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,8 +39,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    if (project.android.hasProperty('namespace') ||
-            getGradle().getGradleVersion().substring(0, 1).toInteger() >= 8) {
+    if (project.android.hasProperty('namespace')) {
         namespace 'io.github.v7lin.tencent_kit'
     }
     


### PR DESCRIPTION
在 android/build.gradle 文件中为项目指定了一个新的命名空间 'io.github.v7lin.tencent_kit'。这有助于在 Android 应用中更好地组织和管理代码，提高模块间的隔离性和可维护性。

参考 wechat_kit： https://github.com/RxReader/wechat_kit/pull/149